### PR TITLE
Wait queue

### DIFF
--- a/SqsQueue.js
+++ b/SqsQueue.js
@@ -3,8 +3,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-
-const logger = require('./logger');
 var uuidgen = require('node-uuid-generator');
 var AWS = require('aws-sdk');
 require('dotenv').config();
@@ -20,18 +18,21 @@ class SqsQueue {
   }
 
   add(messageObj) {
-    const params = {
-      MessageAttributes: {},
-      MessageGroupId: this.groupId,
-      MessageDeduplicationId: uuidgen.generate(),
-      MessageBody: JSON.stringify(messageObj),
-      QueueUrl: this.url
-    };
+    return new Promise((resolve, reject) => {
+      const params = {
+        MessageAttributes: {},
+        MessageGroupId: this.groupId,
+        MessageDeduplicationId: uuidgen.generate(),
+        MessageBody: JSON.stringify(messageObj),
+        QueueUrl: this.url
+      };
 
-    sqs.sendMessage(params, function(err) {
-      if (err) {
-        logger.error('SQS send error', err);
-      }
+      sqs.sendMessage(params, function(err) {
+        if (err) {
+          reject('SQS send error', err);
+        }
+        resolve();
+      });
     });
   }
 }

--- a/index.js
+++ b/index.js
@@ -46,8 +46,8 @@ const failQueue = new SqsQueue(failureQueueURL, 'scout');
  */
 let transcodeInProgress = false;
 const receiveMessage = () => {
+  logger.debug('.');
   sqs.receiveMessage(sqsParams, async function(err, data) {
-    logger.debug('.');
     if (err) {
       logger.error(err);
     }
@@ -77,11 +77,12 @@ const receiveMessage = () => {
               try {
                 transcodeInProgress = true;
                 const newFileName = await transcodeFile(jsonBody.filename);
-                transcodeInProgress = false;
                 await storeFile(newFileName);
               } catch (err) {
                 const errString = `Transcoding error: ${err}`;
                 await addToFailureQueue(message, errString, jsonBody.filename);
+              } finally {
+                transcodeInProgress = false;
               }
             }
           }


### PR DESCRIPTION
Fixes #13 
Fixes #15 

Processes one message at a time from the queue and waits for it to succeed before removing it from the queue. 

* Added `transcodeInProgress` var to prevent the launch of multiple ffmpeg processes. this is useful for large files when the message loop pulls the same message off the queue again
* Added the {filename} value to the messages which are placed in the failure queue. This enables an easy way to retry failed events by pointing the process at the failure queue and restarting. 

Note: for long transcode processes (i.e. those that take longer than the queue's `VisibilityTimeout` setting), the message handle goes stale and removing the message from the queue with that handle will produce an error. This situation will get resolved on the next trip through the queue when we get a fresh handle